### PR TITLE
Move the call to `add_providers()` to the `plugins_loaded` hook

### DIFF
--- a/yahoo-screen.php
+++ b/yahoo-screen.php
@@ -43,7 +43,7 @@ class CFTP_Yahoo_Screen {
 	 * Adds the oembed providers
 	 */
 	public function __construct() {
-		$this->add_providers();
+		add_action( 'plugins_loaded', array( $this, 'add_providers' ) );
 	}
 
 	public function add_providers() {


### PR DESCRIPTION
See https://core.trac.wordpress.org/ticket/28284 for background.
